### PR TITLE
Added reference to n4m-js-bundler project

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Hi Maxers! This repository contains a list of examples using Node For Max create
 - [Nature of Code](https://github.com/dfamil/n4m-examples/tree/master/natureofcode) by [David Familian](https://github.com/dfamil). Examples from [Nature of Code](https://natureofcode.com/) by Daniel Shiffman, Vectors chapter.
 - [Node LOM](https://github.com/iamjoncannon/nodeLOM) by [Jonathan Cannon](https://github.com/iamjoncanno). Enable Node.js to manipulate a Live session in real time and stream session data externally.
 - [QRCode-generator](https://github.com/avantcontra/n4m-qrcode-generator) by [Contra](https://www.floatbug.com/contra/). Generate QRCode image from some text, web URL, etc.
+- [JS Bundler](https://github.com/fde31/n4m-js-bundler) by [fde31](https://github.com/fde31). Node For Max wrapper around the [max-js-bundler CLI Tool](https://github.com/fde31/max-js-bundler) to enable bundling and transpilation of modern JS projects for usage within [js] and [jsui].
 
 ## Contributing
 


### PR DESCRIPTION
I simply extended the README by adding a reference to the n4m-js-bundler project. It's a thin, simple boilerplate wrapper that exposes the functionality of the [max-js-bundler](https://github.com/fde31/max-js-bundler) CLI tool to node.script.

Maybe helpful?!