### PR TITLE
add TypeScript boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Hi Maxers! This repository contains a list of examples using Node For Max create
 ## List of Examples
 
 - [Electron Boilerplate](https://github.com/yuichkun/n4m-electron-boilerplate) by [Yuichi Yogo](https://github.com/yuichkun). A plain boilerplate and guides to develop an electron app for Max.
+- [TypeScript Boilerplate](https://github.com/yuichkun/n4m-typescript-boilerplate) by [Yuichi Yogo](https://github.com/yuichkun). A boilerplate of on-the-fly TypeScript usage.
 - [PoseNet](https://github.com/yuichkun/n4m-posenet) by [Yuichi Yogo](https://github.com/yuichkun). Real-time Human Pose Estimation via webcam.
 - [Watch Youtube](https://github.com/julianrubisch/n4m-examples/tree/master/watch-youtube) by Julian from [Znibbles](https://www.znibbl.es/). Stream YouTube videos from Max.
 - [Static D3.js](https://github.com/julianrubisch/n4m-examples/tree/master/static-d3js) by Julian from [Znibbles](https://www.znibbl.es/). Generate data visualizations with D3.js from Max.


### PR DESCRIPTION
Now that `node.script` accepts command line parameters, I've come to my mind that I could pass in `ts-node/register` to use TypeScript with minimal effort and here's a working example!

By the way, do you guys have the definition file (`@types/max-api.d.ts` kind of thing) of Max API published somewhere? If not, I would really appreciate it if you do!